### PR TITLE
Chore: Make i18n workflow more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ add_subdirectory(po)
 ki18n_install(po)
 
 # Install desktop file -- internationalization function can be seen in po/CMakeLists.txt
-install_internationalized_desktop_file(${CMAKE_SOURCE_DIR}/io.github.DenysMb.Kontainer.desktop ${KDE_INSTALL_APPDIR})
+install_i18n_desktop_file(${CMAKE_SOURCE_DIR}/io.github.DenysMb.Kontainer.desktop ${KDE_INSTALL_APPDIR})
 
 file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES src/*.cpp src/*.h)
 kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -12,9 +12,9 @@ else(NOT GETTEXT_MSGFMT_EXECUTABLE)
         # Beautiful hackery
         # Process .desktop files
         file(GLOB_RECURSE DESKTOP_FILES ${CMAKE_SOURCE_DIR}/*.desktop)
-        set(PROCESSED_DESKTOP_FILES)
 
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/desktopfiles/)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/i18ndesktopfiles/)
 
         # Move all .pot files into the temporary directory and rename them
         # also add to LINGUAS file for msgfmt to accept them
@@ -23,24 +23,44 @@ else(NOT GETTEXT_MSGFMT_EXECUTABLE)
         foreach(_poFileDir ${PO_FILE_DIRS})
                 if(EXISTS ${_poFileDir}/${catalogname}.po)
                         get_filename_component(_poFileDirName ${_poFileDir} NAME)
-                        set(_renamedPoFile ${CMAKE_CURRENT_BINARY_DIR}/desktopfiles/${_poFileDirName}.po)
-                        file(COPY ${_poFileDirName}/${catalogname}.po DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/desktopfiles/)
-                        file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/desktopfiles/${catalogname}.po ${_renamedPoFile})
+                        set(_renamedPoFile ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/${_poFileDirName}.po)
+                        file(COPY ${_poFileDirName}/${catalogname}.po DESTINATION ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/)
+                        file(RENAME ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/${catalogname}.po ${_renamedPoFile})
                         set(LINGUAS_CONTENT "${LINGUAS_CONTENT}${_poFileDirName}\n")
                 endif()
         endforeach(_poFileDir ${PO_FILE_DIRS})
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/desktopfiles/LINGUAS "${LINGUAS_CONTENT}")
+        file(WRITE ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/LINGUAS "${LINGUAS_CONTENT}")
 
-        # Make a function to process & install the internationalised .desktop files in the base dir
-        function(install_internationalized_desktop_file FILE DESTINATION)
+        # Make a function to process & install the internationalized .desktop files in the base dir
+        function(install_i18n_desktop_file FILE DESTINATION)
                 get_filename_component(fileName ${FILE} NAME)
-                set(outputFile ${CMAKE_BINARY_DIR}/${fileName})
+
+                set(outputDir ${CMAKE_BINARY_DIR}/i18ndesktopfiles/)
+                set(outputFile ${outputDir}/${fileName})
+
+                # Determine the unambiguous, full path to the source template FILE.
+                if(IS_ABSOLUTE ${FILE})
+                        set(abs_template_path ${FILE})
+                else()
+                        set(abs_template_path ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+                endif()
+
+                # Safety check: This condition is now less likely to be true even in in-source builds
+                # due to the 'outputDir', unless FILE itself points into that specific subdirectory.
+                if("${abs_template_path}" STREQUAL "${outputFile}")
+                        message(FATAL_ERROR "Input template file '${abs_template_path}' and output file '${outputFile}' are the same path. This will cause a dependency cycle. Please ensure the input FILE points to a source template, not the build output location.")
+                endif()
+
                 add_custom_command(
-                                OUTPUT ${outputFile}
-                                COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --desktop --template=${FILE} -d ${CMAKE_BINARY_DIR}/po/desktopfiles -o ${outputFile}
-                                DEPENDS ${FILE}
+                        OUTPUT ${outputFile}
+                        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --desktop --template=${abs_template_path} -d ${CMAKE_BINARY_DIR}/i18ndesktopfiletranslations/ -o ${outputFile}
+                        DEPENDS ${abs_template_path}
+                        VERBATIM
+                        COMMENT "Generating internationalized ${fileName} into ${outputDir} from ${abs_template_path}"
                 )
-                add_custom_target(process_internationalized_desktop_files ALL DEPENDS ${outputFile})
+
+                add_custom_target(i18n_desktop_file_${fileName} ALL DEPENDS ${outputFile})
+
                 install(PROGRAMS ${outputFile} DESTINATION ${DESTINATION})
         endfunction()
 


### PR DESCRIPTION
Doesn't change any behaviour, just makes it work more consistently. It now works properly with in-source builds and is a bit cleaner and safer in implementation.