### PR TITLE
Add an Init Checkbox.

### DIFF
--- a/src/qml/DistroboxCreateDialog.qml
+++ b/src/qml/DistroboxCreateDialog.qml
@@ -322,7 +322,7 @@ Kirigami.Dialog {
                 Controls.CheckBox {
                     id: initCheckbox
                     Kirigami.FormData.label: i18n("Additional Options")
-                    text: i18n("Add --init --additional-packages \"systemd\"")
+                    text: i18n("Systemd Init Support")
                     checked: false
                 }
             }


### PR DESCRIPTION
Does what the title says. Its an feature that most use in Distroboxes and typing --init --additional-packages "systemd" everytime isnt userfriendly. This adds an optional Checkbox for this arg.

Fixes #35 