### PR TITLE
Add DistroIcons Logic.

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -11,6 +11,9 @@
     "--device=dri",
     "--talk-name=org.freedesktop.Flatpak",
     "--filesystem=~/.local/share/applications:ro"
+    "--filesystem=~/.local/share/icons/distrobox:ro",
+    "--filesystem=~/.local/share/flatpak/exports:ro",
+    "--filesystem=/var/lib/flatpak/exports:ro"
   ],
   "modules": [
     {

--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -10,7 +10,7 @@
     "--socket=wayland",
     "--device=dri",
     "--talk-name=org.freedesktop.Flatpak",
-    "--filesystem=~/.local/share/applications:ro"
+    "--filesystem=~/.local/share/applications:ro",
     "--filesystem=~/.local/share/icons/distrobox:ro",
     "--filesystem=~/.local/share/flatpak/exports:ro",
     "--filesystem=/var/lib/flatpak/exports:ro"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,12 @@ target_include_directories(kontainer
 ecm_target_qml_sources(kontainer
     SOURCES
     qml/Main.qml
+    qml/components/ContainerActionsToolbar.qml
+    qml/components/ContainerBadge.qml
+    qml/components/ContainerCard.qml
+    qml/components/ContainerListStatus.qml
+    qml/components/MainContainersPage.qml
+    qml/components/MainGlobalDrawer.qml
     qml/About.qml
     qml/ApplicationsWindow.qml
     qml/DistroboxCreateDialog.qml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(kontainer
     core/terminallauncher.h
     utils/distrocolors.cpp
     utils/distrocolors.h
+    utils/distroicons.cpp
+    utils/distroicons.h
 )
 
 target_include_directories(kontainer

--- a/src/core/distroboxmanager.cpp
+++ b/src/core/distroboxmanager.cpp
@@ -25,6 +25,7 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QUrl>
+#include <distroicons.h>
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -297,6 +298,12 @@ bool DistroboxManager::launchCommandInTerminal(const QString &command, const QSt
 QString DistroboxManager::getDistroColor(const QString &image)
 {
     return DistroColors::colorForImage(image);
+}
+
+// Returns an Icon associated with the distribution for UI purposes
+QString DistroboxManager::getDistroIcon(const QString &container)
+{
+    return DistroIcons::resolveDistroboxIcon(container);
 }
 
 // Generates .desktop files for applications in containers

--- a/src/core/distroboxmanager.h
+++ b/src/core/distroboxmanager.h
@@ -127,6 +127,13 @@ public Q_SLOTS:
     QString getDistroColor(const QString &image);
 
     /**
+     * @brief Gets an Icon associated with the distribution
+     * @param container Container name
+     * @return Icon for the distribution or generic Fallback
+     */
+    QString getDistroIcon(const QString &container);
+
+    /**
      * @brief Generates desktop entry files for container applications
      * @param name Container name (optional, generates for all containers if empty)
      * @return true if entry generation was successful, false otherwise

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -183,12 +183,6 @@ Kirigami.ApplicationWindow {
                     contentItem: RowLayout {
                         spacing: Kirigami.Units.smallSpacing
 
-                        // Loader {
-                        //     width: Kirigami.Units.smallSpacing
-                        //     Layout.fillHeight: true
-                        //     sourceComponent: root.fallbackToDistroColors ? colorComponent : iconComponent
-                        // }
-
                         Rectangle {
                             visible: root.fallbackToDistroColors
                             width: Kirigami.Units.smallSpacing
@@ -197,14 +191,32 @@ Kirigami.ApplicationWindow {
                             radius: 4
                         }
 
-                        Kirigami.Icon {
+                        Rectangle {
                             visible: !root.fallbackToDistroColors
-                            source: distroBoxManager.getDistroIcon(modelData.name)
-                            width: Kirigami.Units.iconSizes.medium
-                            height: Kirigami.Units.iconSizes.medium
-                            Layout.alignment: Qt.AlignVCenter
-                            Layout.leftMargin: Kirigami.Units.smallSpacing
-                            Layout.rightMargin: Kirigami.Units.smallSpacing
+                            width: Kirigami.Units.iconSizes.medium + Kirigami.Units.smallSpacing * 2
+                            Layout.fillHeight: true
+                            color: {
+                                const baseColor = distroBoxManager.getDistroColor(modelData.image);
+                                if (typeof baseColor === "string" && baseColor.startsWith("#")) {
+                                    const hex = baseColor.slice(1);
+                                    const alphaHex = Math.round(0.15 * 255).toString(16).padStart(2, "0");
+                                    if (hex.length === 6) {
+                                        return "#" + alphaHex + hex;
+                                    }
+                                    if (hex.length === 8) {
+                                        return "#" + alphaHex + hex.slice(2);
+                                    }
+                                }
+                                return Qt.rgba(0, 0, 0, 0.15);
+                            }
+                            radius: 4
+
+                            Kirigami.Icon {
+                                anchors.centerIn: parent
+                                source: distroBoxManager.getDistroIcon(modelData.name)
+                                width: Kirigami.Units.iconSizes.medium
+                                height: Kirigami.Units.iconSizes.medium
+                            }
                         }
 
                         RowLayout {

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -6,9 +6,6 @@
  */
 
 import QtQuick
-import QtQuick.Layouts
-import QtQuick.Controls as Controls
-import QtQuick.Dialogs
 import QtCore
 
 import org.kde.kirigami as Kirigami
@@ -41,7 +38,7 @@ Kirigami.ApplicationWindow {
     function refresh() {
         refreshing = true;
         var result = distroBoxManager.listContainers();
-        mainPage.containersList = JSON.parse(result);
+        containersPage.containersList = JSON.parse(result);
         refreshing = false;
     }
 
@@ -54,64 +51,18 @@ Kirigami.ApplicationWindow {
         }
     }
 
-    globalDrawer: Kirigami.GlobalDrawer {
-        isMenu: true
-        actions: [
-            Kirigami.Action {
-                text: i18n("Create Container…")
-                icon.name: "list-add"
-                onTriggered: createDialog.open()
-            },
-            Kirigami.Action {
-                text: i18n("Create Distrobox Shortcut…")
-                icon.name: "document-new"
-                enabled: mainPage.containersList.length > 0
-                onTriggered: shortcutDialog.open()
-            },
-            Kirigami.Action {
-                separator: true
-            },
-
-            // toggle between distro-provided icons and colors
-            Kirigami.Action {
-                text: i18n("Show Container Icons")
-                icon.name: "view-list-icons"
-                checkable: true
-                checked: !root.fallbackToDistroColors
-                onToggled: root.fallbackToDistroColors = !checked
-            },
-            Kirigami.Action {
-                text: i18n("Clone Container…")
-                icon.name: "edit-copy"
-                enabled: mainPage.containersList.length > 0
-                onTriggered: cloneDialog.openWithContainer("")
-            },
-            Kirigami.Action {
-                separator: true
-            },
-            Kirigami.Action {
-                text: i18n("Open Distrobox Documentation")
-                icon.name: "help-contents"
-                onTriggered: Qt.openUrlExternally("https://distrobox.it/#distrobox")
-            },
-            Kirigami.Action {
-                text: i18n("Open Distrobox Useful Tips")
-                icon.name: "help-hint"
-                onTriggered: Qt.openUrlExternally("https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md")
-            },
-            Kirigami.Action {
-                separator: true
-            },
-            Kirigami.Action {
-                text: i18n("About Kontainer")
-                icon.name: "io.github.DenysMb.Kontainer"
-                onTriggered: {
-                    if (root.pageStack.layers.currentItem !== aboutPage) {
-                        root.pageStack.layers.push(aboutPage);
-                    }
-                }
+    globalDrawer: MainGlobalDrawer {
+        hasContainers: containersPage.containersList.length > 0
+        fallbackToDistroColors: root.fallbackToDistroColors
+        onCreateRequested: createDialog.open()
+        onShortcutRequested: shortcutDialog.open()
+        onCloneRequested: cloneDialog.openWithContainer(containerName)
+        onShowContainerIconsToggled: root.fallbackToDistroColors = fallbackToDistroColors
+        onAboutRequested: {
+            if (root.pageStack.layers.currentItem !== aboutPage) {
+                root.pageStack.layers.push(aboutPage);
             }
-        ]
+        }
     }
 
     ErrorDialog {
@@ -126,221 +77,52 @@ Kirigami.ApplicationWindow {
     }
     DistroboxShortcutDialog {
         id: shortcutDialog
-        containersList: mainPage.containersList
+        containersList: containersPage.containersList
     }
     DistroboxCloneDialog {
         id: cloneDialog
-        containersList: mainPage.containersList
+        containersList: containersPage.containersList
     }
     FilePickerDialog {
         id: packageFileDialog
     }
 
-    pageStack.initialPage: Kirigami.ScrollablePage {
-        id: mainPage
-        spacing: Kirigami.Units.smallSpacing
-        padding: Kirigami.Units.smallSpacing
-
-        title: i18n("Distrobox Containers")
-
-        supportsRefreshing: true
-        onRefreshingChanged: if (refreshing)
-            refresh()
-
-        property var containersList: []
-
-        actions: [
-            Kirigami.Action {
-                text: i18n("Create…")
-                icon.name: "list-add"
-                onTriggered: createDialog.open()
-            },
-            Kirigami.Action {
-                text: i18n("Upgrade all…")
-                icon.name: "system-software-update"
-                onTriggered: distroBoxManager.upgradeAllContainer()
-            },
-            Kirigami.Action {
-                text: i18n("Refresh")
-                icon.name: "view-refresh"
-                onTriggered: refresh()
+    pageStack.initialPage: MainContainersPage {
+        id: containersPage
+        fallbackToDistroColors: root.fallbackToDistroColors
+        appRefreshing: root.refreshing
+        onCreateRequested: createDialog.open()
+        onUpgradeAllRequested: distroBoxManager.upgradeAllContainer()
+        onRefreshRequested: refresh()
+        onInitialLoadRequested: refresh()
+        onInstallPackageRequested: function(containerName, containerImage) {
+            packageFileDialog.containerName = containerName;
+            packageFileDialog.containerImage = containerImage;
+            packageFileDialog.open();
+        }
+        onManageApplicationsRequested: function(containerName) {
+            var component = Qt.createComponent("ApplicationsWindow.qml");
+            if (component.status === Component.Ready) {
+                var window = component.createObject(root, {
+                    containerName: containerName
+                });
+                window.show();
+            } else {
+                console.error("Error loading ApplicationsWindow:", component.errorString());
             }
-        ]
-
-        Component.onCompleted: refresh()
-
-        ColumnLayout {
-            anchors.fill: parent
-            spacing: Kirigami.Units.largeSpacing
-
-            Kirigami.CardsListView {
-                id: containersListView
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                model: mainPage.containersList
-
-                delegate: Kirigami.AbstractCard {
-                    contentItem: RowLayout {
-                        spacing: Kirigami.Units.smallSpacing
-
-                        Rectangle {
-                            visible: root.fallbackToDistroColors
-                            width: Kirigami.Units.smallSpacing
-                            Layout.fillHeight: true
-                            color: distroBoxManager.getDistroColor(modelData.image)
-                            radius: 4
-                        }
-
-                        Rectangle {
-                            visible: !root.fallbackToDistroColors
-                            width: Kirigami.Units.iconSizes.medium + Kirigami.Units.smallSpacing * 2
-                            Layout.fillHeight: true
-                            color: {
-                                const baseColor = distroBoxManager.getDistroColor(modelData.image);
-                                if (typeof baseColor === "string" && baseColor.startsWith("#")) {
-                                    const hex = baseColor.slice(1);
-                                    const alphaHex = Math.round(0.15 * 255).toString(16).padStart(2, "0");
-                                    if (hex.length === 6) {
-                                        return "#" + alphaHex + hex;
-                                    }
-                                    if (hex.length === 8) {
-                                        return "#" + alphaHex + hex.slice(2);
-                                    }
-                                }
-                                return Qt.rgba(0, 0, 0, 0.15);
-                            }
-                            radius: 4
-
-                            Kirigami.Icon {
-                                anchors.centerIn: parent
-                                source: distroBoxManager.getDistroIcon(modelData.name)
-                                width: Kirigami.Units.iconSizes.medium
-                                height: Kirigami.Units.iconSizes.medium
-                            }
-                        }
-
-                        RowLayout {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            Layout.margins: Kirigami.Units.smallSpacing
-
-                            ColumnLayout {
-                                spacing: Kirigami.Units.smallSpacing
-                                Layout.maximumWidth: implicitWidth
-
-                                Controls.Label {
-                                    text: modelData.name.charAt(0).toUpperCase() + modelData.name.slice(1)
-                                    elide: Text.ElideRight
-                                    Layout.fillWidth: true
-                                    font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.1
-                                    font.bold: true
-                                }
-
-                                Controls.Label {
-                                    text: modelData.image
-                                    elide: Text.ElideRight
-                                    Layout.fillWidth: true
-                                    font.pointSize: Kirigami.Theme.smallFont.pointSize
-                                    opacity: 0.7
-                                }
-                            }
-
-                            Kirigami.ActionToolBar {
-                                id: actionToolBar
-                                Layout.fillWidth: true
-                                spacing: Kirigami.Units.smallSpacing
-                                alignment: Qt.AlignRight
-                                display: Controls.Button.IconOnly
-                                flat: false
-
-                                actions: [
-                                    Kirigami.Action {
-                                        icon.name: "package-x-generic"
-                                        text: i18n("Install Package")
-                                        onTriggered: {
-                                            packageFileDialog.containerName = modelData.name;
-                                            packageFileDialog.containerImage = modelData.image;
-                                            packageFileDialog.open();
-                                        }
-                                    },
-                                    Kirigami.Action {
-                                        icon.name: "applications-all-symbolic"
-                                        text: i18n("Manage Applications")
-                                        onTriggered: {
-                                            var component = Qt.createComponent("ApplicationsWindow.qml");
-                                            if (component.status === Component.Ready) {
-                                                var window = component.createObject(root, {
-                                                    containerName: modelData.name
-                                                });
-                                                window.show();
-                                            } else {
-                                                console.error("Error loading ApplicationsWindow:", component.errorString());
-                                            }
-                                        }
-                                    },
-                                    Kirigami.Action {
-                                        icon.name: "utilities-terminal-symbolic"
-                                        text: i18n("Open Terminal")
-                                        onTriggered: {
-                                            distroBoxManager.enterContainer(modelData.name);
-                                        }
-                                    },
-                                    Kirigami.Action {
-                                        text: i18n("More options")
-                                        icon.name: "view-more-symbolic"
-                                        Kirigami.Action {
-                                            icon.name: "system-software-update"
-                                            text: i18n("Upgrade Container")
-                                            onTriggered: {
-                                                distroBoxManager.upgradeContainer(modelData.name);
-                                            }
-                                        }
-                                        Kirigami.Action {
-                                            icon.name: "edit-copy"
-                                            text: i18n("Clone Container")
-                                            onTriggered: {
-                                                cloneDialog.openWithContainer(modelData.name);
-                                            }
-                                        }
-                                        Kirigami.Action {
-                                            icon.name: "delete"
-                                            text: i18n("Remove Container")
-                                            onTriggered: {
-                                                removeDialog.containerName = modelData.name;
-                                                removeDialog.open();
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-
-                Kirigami.PlaceholderMessage {
-                    anchors.centerIn: parent
-                    visible: containersListView.count === 0 && !refreshing
-                    text: i18n("No containers found. Create a new container now?")
-                    helpfulAction: Kirigami.Action {
-                        text: i18n("Create Container")
-                        icon.name: "list-add"
-                        onTriggered: createDialog.open()
-                    }
-                }
-
-                Controls.BusyIndicator {
-                    anchors.centerIn: parent
-                    visible: containersListView.count === 0 && refreshing && !loadingTimer.running
-                }
-
-                Timer {
-                    id: loadingTimer
-                    interval: 100
-                    repeat: false
-                }
-
-                Component.onCompleted: loadingTimer.start()
-            }
+        }
+        onOpenTerminalRequested: function(containerName) {
+            distroBoxManager.enterContainer(containerName);
+        }
+        onUpgradeContainerRequested: function(containerName) {
+            distroBoxManager.upgradeContainer(containerName);
+        }
+        onCloneContainerRequested: function(containerName) {
+            cloneDialog.openWithContainer(containerName);
+        }
+        onRemoveContainerRequested: function(containerName) {
+            removeDialog.containerName = containerName;
+            removeDialog.open();
         }
     }
 }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -9,6 +9,7 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as Controls
 import QtQuick.Dialogs
+import QtCore
 
 import org.kde.kirigami as Kirigami
 
@@ -26,7 +27,16 @@ Kirigami.ApplicationWindow {
     }
 
     property bool refreshing: false
-    property bool fallbackToDistroColors: false
+
+    // persistent settings storage using QtCore.Settings
+    Settings {
+        id: kontainerSettings
+        category: "Appearance"
+        property bool showColors: false
+    }
+
+    // alias for clarity
+    property alias fallbackToDistroColors: kontainerSettings.showColors
 
     function refresh() {
         refreshing = true;
@@ -58,25 +68,30 @@ Kirigami.ApplicationWindow {
                 enabled: mainPage.containersList.length > 0
                 onTriggered: shortcutDialog.open()
             },
+            Kirigami.Action { separator: true },
+
+            // clearer toggle action
+            Kirigami.Action {
+                text: root.fallbackToDistroColors
+                ? i18n("Show Container Icons")
+                : i18n("Show Container Colors")
+                icon.name: root.fallbackToDistroColors
+                ? "preferences-desktop-icons"
+                : "preferences-desktop-color"
+                onTriggered: {
+                    root.fallbackToDistroColors = !root.fallbackToDistroColors
+                }
+            },
+
             Kirigami.Action {
                 text: i18n("Clone Container…")
                 icon.name: "edit-copy"
                 enabled: mainPage.containersList.length > 0
                 onTriggered: cloneDialog.openWithContainer("")
             },
-            Kirigami.Action {
-                separator: true
-            },
-            Kirigami.Action {
-                text: root.fallbackToDistroColors ? i18n("Use Icons") : i18n("Use Colors")
-                icon.name: root.fallbackToDistroColors ? "preferences-desktop-icons" : "preferences-desktop-color"
-                onTriggered: {
-                    root.fallbackToDistroColors = !root.fallbackToDistroColors;
-                }
-            },
-            Kirigami.Action {
-                separator: true
-            },
+
+            Kirigami.Action { separator: true },
+
             Kirigami.Action {
                 text: i18n("Open Distrobox Documentation")
                 icon.name: "help-contents"
@@ -87,47 +102,25 @@ Kirigami.ApplicationWindow {
                 icon.name: "help-hint"
                 onTriggered: Qt.openUrlExternally("https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md")
             },
-            Kirigami.Action {
-                separator: true
-            },
+            Kirigami.Action { separator: true },
             Kirigami.Action {
                 text: i18n("About Kontainer")
                 icon.name: "io.github.DenysMb.Kontainer"
                 onTriggered: {
                     if (root.pageStack.layers.currentItem !== aboutPage) {
-                        root.pageStack.layers.push(aboutPage);
+                        root.pageStack.layers.push(aboutPage)
                     }
                 }
             }
         ]
     }
 
-    ErrorDialog {
-        id: errorDialog
-    }
-
-    DistroboxRemoveDialog {
-        id: removeDialog
-    }
-
-    DistroboxCreateDialog {
-        id: createDialog
-        errorDialog: errorDialog
-    }
-
-    DistroboxShortcutDialog {
-        id: shortcutDialog
-        containersList: mainPage.containersList
-    }
-
-    DistroboxCloneDialog {
-        id: cloneDialog
-        containersList: mainPage.containersList
-    }
-
-    FilePickerDialog {
-        id: packageFileDialog
-    }
+    ErrorDialog { id: errorDialog }
+    DistroboxRemoveDialog { id: removeDialog }
+    DistroboxCreateDialog { id: createDialog; errorDialog: errorDialog }
+    DistroboxShortcutDialog { id: shortcutDialog; containersList: mainPage.containersList }
+    DistroboxCloneDialog { id: cloneDialog; containersList: mainPage.containersList }
+    FilePickerDialog { id: packageFileDialog }
 
     pageStack.initialPage: Kirigami.ScrollablePage {
         id: mainPage
@@ -137,11 +130,7 @@ Kirigami.ApplicationWindow {
         title: i18n("Distrobox Containers")
 
         supportsRefreshing: true
-        onRefreshingChanged: {
-            if (refreshing) {
-                refresh();
-            }
-        }
+        onRefreshingChanged: if (refreshing) refresh()
 
         property var containersList: []
 
@@ -163,9 +152,7 @@ Kirigami.ApplicationWindow {
             }
         ]
 
-        Component.onCompleted: {
-            refresh();
-        }
+        Component.onCompleted: refresh()
 
         ColumnLayout {
             anchors.fill: parent
@@ -181,7 +168,6 @@ Kirigami.ApplicationWindow {
                     contentItem: RowLayout {
                         spacing: Kirigami.Units.smallSpacing
 
-                        // Conditional rendering based on fallbackToDistroColors setting
                         Loader {
                             width: Kirigami.Units.smallSpacing
                             Layout.fillHeight: true
@@ -191,8 +177,8 @@ Kirigami.ApplicationWindow {
                         Component {
                             id: colorComponent
                             Rectangle {
-                                width: Kirigami.Units.smallSpacing
-                                height: parent.height
+                                width: Kirigami.Units.iconSizes.medium
+                                height: Kirigami.Units.iconSizes.medium
                                 color: distroBoxManager.getDistroColor(modelData.image)
                                 radius: 4
                             }
@@ -238,7 +224,6 @@ Kirigami.ApplicationWindow {
 
                             Kirigami.ActionToolBar {
                                 id: actionToolBar
-
                                 Layout.fillWidth: true
                                 spacing: Kirigami.Units.smallSpacing
                                 alignment: Qt.AlignRight
@@ -250,23 +235,23 @@ Kirigami.ApplicationWindow {
                                         icon.name: "package-x-generic"
                                         text: i18n("Install Package")
                                         onTriggered: {
-                                            packageFileDialog.containerName = modelData.name;
-                                            packageFileDialog.containerImage = modelData.image;
-                                            packageFileDialog.open();
+                                            packageFileDialog.containerName = modelData.name
+                                            packageFileDialog.containerImage = modelData.image
+                                            packageFileDialog.open()
                                         }
                                     },
                                     Kirigami.Action {
                                         icon.name: "applications-all-symbolic"
                                         text: i18n("Manage Applications")
                                         onTriggered: {
-                                            var component = Qt.createComponent("ApplicationsWindow.qml");
+                                            var component = Qt.createComponent("ApplicationsWindow.qml")
                                             if (component.status === Component.Ready) {
                                                 var window = component.createObject(root, {
                                                     containerName: modelData.name
-                                                });
-                                                window.show();
+                                                })
+                                                window.show()
                                             } else {
-                                                console.error("Error loading ApplicationsWindow:", component.errorString());
+                                                console.error("Error loading ApplicationsWindow:", component.errorString())
                                             }
                                         }
                                     },
@@ -331,9 +316,7 @@ Kirigami.ApplicationWindow {
                     repeat: false
                 }
 
-                Component.onCompleted: {
-                    loadingTimer.start();
-                }
+                Component.onCompleted: loadingTimer.start()
             }
         }
     }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -68,30 +68,27 @@ Kirigami.ApplicationWindow {
                 enabled: mainPage.containersList.length > 0
                 onTriggered: shortcutDialog.open()
             },
-            Kirigami.Action { separator: true },
-
-            // clearer toggle action
             Kirigami.Action {
-                text: root.fallbackToDistroColors
-                ? i18n("Show Container Icons")
-                : i18n("Show Container Colors")
-                icon.name: root.fallbackToDistroColors
-                ? "preferences-desktop-icons"
-                : "preferences-desktop-color"
-                onTriggered: {
-                    root.fallbackToDistroColors = !root.fallbackToDistroColors
-                }
+                separator: true
             },
 
+            // toggle between distro-provided icons and colors
+            Kirigami.Action {
+                text: i18n("Show Container Icons")
+                icon.name: "view-list-icons"
+                checkable: true
+                checked: !root.fallbackToDistroColors
+                onToggled: root.fallbackToDistroColors = !checked
+            },
             Kirigami.Action {
                 text: i18n("Clone Container…")
                 icon.name: "edit-copy"
                 enabled: mainPage.containersList.length > 0
                 onTriggered: cloneDialog.openWithContainer("")
             },
-
-            Kirigami.Action { separator: true },
-
+            Kirigami.Action {
+                separator: true
+            },
             Kirigami.Action {
                 text: i18n("Open Distrobox Documentation")
                 icon.name: "help-contents"
@@ -102,25 +99,42 @@ Kirigami.ApplicationWindow {
                 icon.name: "help-hint"
                 onTriggered: Qt.openUrlExternally("https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md")
             },
-            Kirigami.Action { separator: true },
+            Kirigami.Action {
+                separator: true
+            },
             Kirigami.Action {
                 text: i18n("About Kontainer")
                 icon.name: "io.github.DenysMb.Kontainer"
                 onTriggered: {
                     if (root.pageStack.layers.currentItem !== aboutPage) {
-                        root.pageStack.layers.push(aboutPage)
+                        root.pageStack.layers.push(aboutPage);
                     }
                 }
             }
         ]
     }
 
-    ErrorDialog { id: errorDialog }
-    DistroboxRemoveDialog { id: removeDialog }
-    DistroboxCreateDialog { id: createDialog; errorDialog: errorDialog }
-    DistroboxShortcutDialog { id: shortcutDialog; containersList: mainPage.containersList }
-    DistroboxCloneDialog { id: cloneDialog; containersList: mainPage.containersList }
-    FilePickerDialog { id: packageFileDialog }
+    ErrorDialog {
+        id: errorDialog
+    }
+    DistroboxRemoveDialog {
+        id: removeDialog
+    }
+    DistroboxCreateDialog {
+        id: createDialog
+        errorDialog: errorDialog
+    }
+    DistroboxShortcutDialog {
+        id: shortcutDialog
+        containersList: mainPage.containersList
+    }
+    DistroboxCloneDialog {
+        id: cloneDialog
+        containersList: mainPage.containersList
+    }
+    FilePickerDialog {
+        id: packageFileDialog
+    }
 
     pageStack.initialPage: Kirigami.ScrollablePage {
         id: mainPage
@@ -130,7 +144,8 @@ Kirigami.ApplicationWindow {
         title: i18n("Distrobox Containers")
 
         supportsRefreshing: true
-        onRefreshingChanged: if (refreshing) refresh()
+        onRefreshingChanged: if (refreshing)
+            refresh()
 
         property var containersList: []
 
@@ -168,32 +183,28 @@ Kirigami.ApplicationWindow {
                     contentItem: RowLayout {
                         spacing: Kirigami.Units.smallSpacing
 
-                        Loader {
+                        // Loader {
+                        //     width: Kirigami.Units.smallSpacing
+                        //     Layout.fillHeight: true
+                        //     sourceComponent: root.fallbackToDistroColors ? colorComponent : iconComponent
+                        // }
+
+                        Rectangle {
+                            visible: root.fallbackToDistroColors
                             width: Kirigami.Units.smallSpacing
                             Layout.fillHeight: true
-                            sourceComponent: root.fallbackToDistroColors ? colorComponent : iconComponent
+                            color: distroBoxManager.getDistroColor(modelData.image)
+                            radius: 4
                         }
 
-                        Component {
-                            id: colorComponent
-                            Rectangle {
-                                width: Kirigami.Units.iconSizes.medium
-                                height: Kirigami.Units.iconSizes.medium
-                                color: distroBoxManager.getDistroColor(modelData.image)
-                                radius: 4
-                            }
-                        }
-
-                        Component {
-                            id: iconComponent
-                            Kirigami.Icon {
-                                source: distroBoxManager.getDistroIcon(modelData.name)
-                                width: Kirigami.Units.iconSizes.medium
-                                height: Kirigami.Units.iconSizes.medium
-                                Layout.alignment: Qt.AlignTop
-                                Layout.leftMargin: Kirigami.Units.smallSpacing
-                                Layout.topMargin: Kirigami.Units.smallSpacing
-                            }
+                        Kirigami.Icon {
+                            visible: !root.fallbackToDistroColors
+                            source: distroBoxManager.getDistroIcon(modelData.name)
+                            width: Kirigami.Units.iconSizes.medium
+                            height: Kirigami.Units.iconSizes.medium
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.leftMargin: Kirigami.Units.smallSpacing
+                            Layout.rightMargin: Kirigami.Units.smallSpacing
                         }
 
                         RowLayout {
@@ -235,23 +246,23 @@ Kirigami.ApplicationWindow {
                                         icon.name: "package-x-generic"
                                         text: i18n("Install Package")
                                         onTriggered: {
-                                            packageFileDialog.containerName = modelData.name
-                                            packageFileDialog.containerImage = modelData.image
-                                            packageFileDialog.open()
+                                            packageFileDialog.containerName = modelData.name;
+                                            packageFileDialog.containerImage = modelData.image;
+                                            packageFileDialog.open();
                                         }
                                     },
                                     Kirigami.Action {
                                         icon.name: "applications-all-symbolic"
                                         text: i18n("Manage Applications")
                                         onTriggered: {
-                                            var component = Qt.createComponent("ApplicationsWindow.qml")
+                                            var component = Qt.createComponent("ApplicationsWindow.qml");
                                             if (component.status === Component.Ready) {
                                                 var window = component.createObject(root, {
                                                     containerName: modelData.name
-                                                })
-                                                window.show()
+                                                });
+                                                window.show();
                                             } else {
-                                                console.error("Error loading ApplicationsWindow:", component.errorString())
+                                                console.error("Error loading ApplicationsWindow:", component.errorString());
                                             }
                                         }
                                     },

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -26,6 +26,7 @@ Kirigami.ApplicationWindow {
     }
 
     property bool refreshing: false
+    property bool fallbackToDistroColors: false
 
     function refresh() {
         refreshing = true;
@@ -62,6 +63,16 @@ Kirigami.ApplicationWindow {
                 icon.name: "edit-copy"
                 enabled: mainPage.containersList.length > 0
                 onTriggered: cloneDialog.openWithContainer("")
+            },
+            Kirigami.Action {
+                separator: true
+            },
+            Kirigami.Action {
+                text: root.fallbackToDistroColors ? i18n("Use Icons") : i18n("Use Colors")
+                icon.name: root.fallbackToDistroColors ? "preferences-desktop-icons" : "preferences-desktop-color"
+                onTriggered: {
+                    root.fallbackToDistroColors = !root.fallbackToDistroColors;
+                }
             },
             Kirigami.Action {
                 separator: true
@@ -170,24 +181,33 @@ Kirigami.ApplicationWindow {
                     contentItem: RowLayout {
                         spacing: Kirigami.Units.smallSpacing
 
-                        // Old colour logic - commented out
-                        /*
-                         *                       Rectangle {
-                         *                           width: Kirigami.Units.smallSpacing
-                         *                           Layout.fillHeight: true
-                         *                           color: distroBoxManager.getDistroColor(modelData.image)
-                         *                           radius: 4
-                    }
-                    */
+                        // Conditional rendering based on fallbackToDistroColors setting
+                        Loader {
+                            width: Kirigami.Units.smallSpacing
+                            Layout.fillHeight: true
+                            sourceComponent: root.fallbackToDistroColors ? colorComponent : iconComponent
+                        }
 
-                        // New icon logic
-                        Kirigami.Icon {
-                            source: distroBoxManager.getDistroIcon(modelData.name)
-                            width: Kirigami.Units.iconSizes.medium
-                            height: Kirigami.Units.iconSizes.medium
-                            Layout.alignment: Qt.AlignTop
-                            Layout.leftMargin: Kirigami.Units.smallSpacing
-                            Layout.topMargin: Kirigami.Units.smallSpacing
+                        Component {
+                            id: colorComponent
+                            Rectangle {
+                                width: Kirigami.Units.smallSpacing
+                                height: parent.height
+                                color: distroBoxManager.getDistroColor(modelData.image)
+                                radius: 4
+                            }
+                        }
+
+                        Component {
+                            id: iconComponent
+                            Kirigami.Icon {
+                                source: distroBoxManager.getDistroIcon(modelData.name)
+                                width: Kirigami.Units.iconSizes.medium
+                                height: Kirigami.Units.iconSizes.medium
+                                Layout.alignment: Qt.AlignTop
+                                Layout.leftMargin: Kirigami.Units.smallSpacing
+                                Layout.topMargin: Kirigami.Units.smallSpacing
+                            }
                         }
 
                         RowLayout {

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -170,11 +170,24 @@ Kirigami.ApplicationWindow {
                     contentItem: RowLayout {
                         spacing: Kirigami.Units.smallSpacing
 
-                        Rectangle {
-                            width: Kirigami.Units.smallSpacing
-                            Layout.fillHeight: true
-                            color: distroBoxManager.getDistroColor(modelData.image)
-                            radius: 4
+                        // Old colour logic - commented out
+                        /*
+                         *                       Rectangle {
+                         *                           width: Kirigami.Units.smallSpacing
+                         *                           Layout.fillHeight: true
+                         *                           color: distroBoxManager.getDistroColor(modelData.image)
+                         *                           radius: 4
+                    }
+                    */
+
+                        // New icon logic
+                        Kirigami.Icon {
+                            source: distroBoxManager.getDistroIcon(modelData.name)
+                            width: Kirigami.Units.iconSizes.medium
+                            height: Kirigami.Units.iconSizes.medium
+                            Layout.alignment: Qt.AlignTop
+                            Layout.leftMargin: Kirigami.Units.smallSpacing
+                            Layout.topMargin: Kirigami.Units.smallSpacing
                         }
 
                         RowLayout {

--- a/src/qml/components/ContainerActionsToolbar.qml
+++ b/src/qml/components/ContainerActionsToolbar.qml
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Kirigami.ActionToolBar {
+    id: toolbar
+
+    property string containerName: ""
+    property string containerImage: ""
+
+    signal installPackageRequested(string containerName, string containerImage)
+    signal manageApplicationsRequested(string containerName)
+    signal openTerminalRequested(string containerName)
+    signal upgradeContainerRequested(string containerName)
+    signal cloneContainerRequested(string containerName)
+    signal removeContainerRequested(string containerName)
+
+    Layout.fillWidth: true
+    Layout.fillHeight: true
+    spacing: Kirigami.Units.smallSpacing
+    alignment: Qt.AlignRight
+    display: Controls.Button.IconOnly
+    flat: false
+
+    actions: [
+        Kirigami.Action {
+            icon.name: "package-x-generic"
+            text: i18n("Install Package")
+            onTriggered: toolbar.installPackageRequested(toolbar.containerName, toolbar.containerImage)
+        },
+        Kirigami.Action {
+            icon.name: "applications-all-symbolic"
+            text: i18n("Manage Applications")
+            onTriggered: toolbar.manageApplicationsRequested(toolbar.containerName)
+        },
+        Kirigami.Action {
+            icon.name: "utilities-terminal-symbolic"
+            text: i18n("Open Terminal")
+            onTriggered: toolbar.openTerminalRequested(toolbar.containerName)
+        },
+        Kirigami.Action {
+            text: i18n("More options")
+            icon.name: "view-more-symbolic"
+            Kirigami.Action {
+                icon.name: "system-software-update"
+                text: i18n("Upgrade Container")
+                onTriggered: toolbar.upgradeContainerRequested(toolbar.containerName)
+            }
+            Kirigami.Action {
+                icon.name: "edit-copy"
+                text: i18n("Clone Container")
+                onTriggered: toolbar.cloneContainerRequested(toolbar.containerName)
+            }
+            Kirigami.Action {
+                icon.name: "delete"
+                text: i18n("Remove Container")
+                onTriggered: toolbar.removeContainerRequested(toolbar.containerName)
+            }
+        }
+    ]
+}

--- a/src/qml/components/ContainerBadge.qml
+++ b/src/qml/components/ContainerBadge.qml
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Item {
+    id: badge
+
+    property bool fallbackToDistroColors: false
+    property string containerName: ""
+    property string containerImage: ""
+
+    Layout.fillHeight: true
+    implicitWidth: fallbackToDistroColors ? fallbackColorStrip.implicitWidth : iconContainer.implicitWidth
+    implicitHeight: iconContainer.implicitHeight
+
+    Rectangle {
+        id: fallbackColorStrip
+        visible: badge.fallbackToDistroColors
+        width: Kirigami.Units.smallSpacing
+        implicitWidth: width
+        anchors.fill: parent
+        color: distroBoxManager.getDistroColor(badge.containerImage)
+        radius: 4
+    }
+
+    Rectangle {
+        id: iconContainer
+        visible: !badge.fallbackToDistroColors
+        width: Kirigami.Units.iconSizes.medium + Kirigami.Units.smallSpacing * 2
+        implicitWidth: width
+        height: Kirigami.Units.iconSizes.medium + Kirigami.Units.smallSpacing * 2
+        implicitHeight: height
+        anchors.verticalCenter: parent.verticalCenter
+        color: {
+            const baseColor = distroBoxManager.getDistroColor(badge.containerImage);
+            if (typeof baseColor === "string" && baseColor.startsWith("#")) {
+                const hex = baseColor.slice(1);
+                const alphaHex = Math.round(0.15 * 255).toString(16).padStart(2, "0");
+                if (hex.length === 6) {
+                    return "#" + alphaHex + hex;
+                }
+                if (hex.length === 8) {
+                    return "#" + alphaHex + hex.slice(2);
+                }
+            }
+            return Qt.rgba(0, 0, 0, 0.15);
+        }
+        radius: 4
+
+        Kirigami.Icon {
+            anchors.centerIn: parent
+            source: distroBoxManager.getDistroIcon(badge.containerName)
+            width: Kirigami.Units.iconSizes.medium
+            height: Kirigami.Units.iconSizes.medium
+        }
+    }
+}

--- a/src/qml/components/ContainerCard.qml
+++ b/src/qml/components/ContainerCard.qml
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Kirigami.AbstractCard {
+    id: card
+
+    property var container: ({})
+    property bool fallbackToDistroColors: false
+
+    signal installPackageRequested(string containerName, string containerImage)
+    signal manageApplicationsRequested(string containerName)
+    signal openTerminalRequested(string containerName)
+    signal upgradeContainerRequested(string containerName)
+    signal cloneContainerRequested(string containerName)
+    signal removeContainerRequested(string containerName)
+
+    contentItem: RowLayout {
+        spacing: Kirigami.Units.smallSpacing
+
+        ContainerBadge {
+            fallbackToDistroColors: card.fallbackToDistroColors
+            containerName: card.container.name || ""
+            containerImage: card.container.image || ""
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: Kirigami.Units.smallSpacing
+
+            ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+                Layout.maximumWidth: implicitWidth
+
+                Controls.Label {
+                    text: card.container.name ? card.container.name.charAt(0).toUpperCase() + card.container.name.slice(1) : ""
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                    font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.1
+                    font.bold: true
+                }
+
+                Controls.Label {
+                    text: card.container.image || ""
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                    font.pointSize: Kirigami.Theme.smallFont.pointSize
+                    opacity: 0.7
+                }
+            }
+
+            ContainerActionsToolbar {
+                containerName: card.container.name || ""
+                containerImage: card.container.image || ""
+                onInstallPackageRequested: card.installPackageRequested(containerName, containerImage)
+                onManageApplicationsRequested: card.manageApplicationsRequested(containerName)
+                onOpenTerminalRequested: card.openTerminalRequested(containerName)
+                onUpgradeContainerRequested: card.upgradeContainerRequested(containerName)
+                onCloneContainerRequested: card.cloneContainerRequested(containerName)
+                onRemoveContainerRequested: card.removeContainerRequested(containerName)
+            }
+        }
+    }
+}

--- a/src/qml/components/ContainerListStatus.qml
+++ b/src/qml/components/ContainerListStatus.qml
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls as Controls
+import org.kde.kirigami as Kirigami
+
+Item {
+    id: status
+
+    property bool isEmpty: true
+    property bool isRefreshing: false
+
+    signal createRequested()
+
+    anchors.fill: parent
+
+    Kirigami.PlaceholderMessage {
+        anchors.centerIn: parent
+        visible: status.isEmpty && !status.isRefreshing
+        text: i18n("No containers found. Create a new container now?")
+        helpfulAction: Kirigami.Action {
+            text: i18n("Create Container")
+            icon.name: "list-add"
+            onTriggered: status.createRequested()
+        }
+    }
+
+    Controls.BusyIndicator {
+        anchors.centerIn: parent
+        visible: status.isEmpty && status.isRefreshing && !loadingTimer.running
+    }
+
+    Timer {
+        id: loadingTimer
+        interval: 100
+        repeat: false
+    }
+
+    Component.onCompleted: loadingTimer.start()
+}

--- a/src/qml/components/MainContainersPage.qml
+++ b/src/qml/components/MainContainersPage.qml
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Kirigami.ScrollablePage {
+    id: page
+
+    property var containersList: []
+    property bool appRefreshing: false
+    property bool fallbackToDistroColors: false
+
+    signal createRequested()
+    signal upgradeAllRequested()
+    signal refreshRequested()
+    signal initialLoadRequested()
+    signal installPackageRequested(string containerName, string containerImage)
+    signal manageApplicationsRequested(string containerName)
+    signal openTerminalRequested(string containerName)
+    signal upgradeContainerRequested(string containerName)
+    signal cloneContainerRequested(string containerName)
+    signal removeContainerRequested(string containerName)
+
+    spacing: Kirigami.Units.smallSpacing
+    padding: Kirigami.Units.smallSpacing
+
+    title: i18n("Distrobox Containers")
+
+    supportsRefreshing: true
+    onRefreshingChanged: if (refreshing)
+        page.refreshRequested()
+
+    actions: [
+        Kirigami.Action {
+            text: i18n("Create…")
+            icon.name: "list-add"
+            onTriggered: page.createRequested()
+        },
+        Kirigami.Action {
+            text: i18n("Upgrade all…")
+            icon.name: "system-software-update"
+            onTriggered: page.upgradeAllRequested()
+        },
+        Kirigami.Action {
+            text: i18n("Refresh")
+            icon.name: "view-refresh"
+            onTriggered: page.refreshRequested()
+        }
+    ]
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: Kirigami.Units.largeSpacing
+
+        Kirigami.CardsListView {
+            id: containersListView
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: page.containersList
+
+            delegate: ContainerCard {
+                container: modelData
+                fallbackToDistroColors: page.fallbackToDistroColors
+                onInstallPackageRequested: page.installPackageRequested(containerName, containerImage)
+                onManageApplicationsRequested: page.manageApplicationsRequested(containerName)
+                onOpenTerminalRequested: page.openTerminalRequested(containerName)
+                onUpgradeContainerRequested: page.upgradeContainerRequested(containerName)
+                onCloneContainerRequested: page.cloneContainerRequested(containerName)
+                onRemoveContainerRequested: page.removeContainerRequested(containerName)
+            }
+
+            ContainerListStatus {
+                isEmpty: containersListView.count === 0
+                isRefreshing: page.appRefreshing
+                onCreateRequested: page.createRequested()
+            }
+        }
+    }
+
+    Component.onCompleted: page.initialLoadRequested()
+}

--- a/src/qml/components/MainGlobalDrawer.qml
+++ b/src/qml/components/MainGlobalDrawer.qml
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick
+import org.kde.kirigami as Kirigami
+
+Kirigami.GlobalDrawer {
+    id: drawer
+
+    property bool hasContainers: false
+    property bool fallbackToDistroColors: false
+
+    signal createRequested()
+    signal shortcutRequested()
+    signal cloneRequested(string containerName)
+    signal showContainerIconsToggled(bool fallbackToDistroColors)
+    signal aboutRequested()
+
+    isMenu: true
+
+    actions: [
+        Kirigami.Action {
+            text: i18n("Create Container…")
+            icon.name: "list-add"
+            onTriggered: drawer.createRequested()
+        },
+        Kirigami.Action {
+            text: i18n("Create Distrobox Shortcut…")
+            icon.name: "document-new"
+            enabled: drawer.hasContainers
+            onTriggered: drawer.shortcutRequested()
+        },
+        Kirigami.Action {
+            separator: true
+        },
+        Kirigami.Action {
+            text: i18n("Show Container Icons")
+            icon.name: "view-list-icons"
+            checkable: true
+            checked: !drawer.fallbackToDistroColors
+            onToggled: drawer.showContainerIconsToggled(!checked)
+        },
+        Kirigami.Action {
+            text: i18n("Clone Container…")
+            icon.name: "edit-copy"
+            enabled: drawer.hasContainers
+            onTriggered: drawer.cloneRequested("")
+        },
+        Kirigami.Action {
+            separator: true
+        },
+        Kirigami.Action {
+            text: i18n("Open Distrobox Documentation")
+            icon.name: "help-contents"
+            onTriggered: Qt.openUrlExternally("https://distrobox.it/#distrobox")
+        },
+        Kirigami.Action {
+            text: i18n("Open Distrobox Useful Tips")
+            icon.name: "help-hint"
+            onTriggered: Qt.openUrlExternally("https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md")
+        },
+        Kirigami.Action {
+            separator: true
+        },
+        Kirigami.Action {
+            text: i18n("About Kontainer")
+            icon.name: "io.github.DenysMb.Kontainer"
+            onTriggered: drawer.aboutRequested()
+        }
+    ]
+}

--- a/src/utils/distroicons.cpp
+++ b/src/utils/distroicons.cpp
@@ -20,7 +20,6 @@ QString resolveDistroboxIcon(const QString container)
     QStringList searchPaths;
 
     if (isFlatpakRuntime) {
-        // In Flatpak, search multiple possible locations for exported desktop files
         searchPaths = {QDir::homePath() + QStringLiteral("/.var/app/io.github.DenysMb.Kontainer/data/applications"),
                        QDir::homePath() + QStringLiteral("/.var/app/io.github.DenysMb.Kontainer/.local/share/applications"),
                        QStringLiteral("/var/lib/flatpak/exports/share/applications"),
@@ -33,7 +32,7 @@ QString resolveDistroboxIcon(const QString container)
     QStringList patterns;
     patterns << QStringLiteral("%1.desktop").arg(container);
 
-    // Search in all possible paths
+    // 1. Try to resolve from .desktop file
     for (const QString &searchPath : searchPaths) {
         QDir dir(searchPath);
         if (!dir.exists())
@@ -46,16 +45,18 @@ QString resolveDistroboxIcon(const QString container)
             QSettings desktop(file.filePath(), QSettings::IniFormat);
             QString foundIcon = desktop.value(QStringLiteral("Desktop Entry/Icon"), QString()).toString();
 
-            // Stop at first .desktop (even if no icon is set)
             if (!foundIcon.isEmpty())
                 return foundIcon;
-            else
-                return QStringLiteral("preferences-virtualization-container");
         }
     }
 
-    // Fallback if no .desktop file was found at all
+    // 2. Fallback to distrobox terminal icon
+    QString customIconPath = QDir::homePath() + QStringLiteral("/.local/share/icons/distrobox/terminal-distrobox-icon.svg");
+    if (QFile::exists(customIconPath)) {
+        return customIconPath;
+    }
+
+    // 3. Super final fallback
     return QStringLiteral("preferences-virtualization-container");
 }
-
 }

--- a/src/utils/distroicons.cpp
+++ b/src/utils/distroicons.cpp
@@ -1,0 +1,61 @@
+/*
+ *    SPDX-License-Identifier: GPL-3.0-or-later
+ *    SPDX-FileCopyrightText: 2025 Hadi Chokr <hadichokr@icloud.com>
+ */
+
+#include "distroicons.h"
+
+#include "distroboxcli.h"
+#include <QDir>
+#include <QSettings>
+#include <QStandardPaths>
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace DistroIcons
+{
+QString resolveDistroboxIcon(const QString container)
+{
+    bool isFlatpakRuntime = DistroboxCli::isFlatpak();
+    QStringList searchPaths;
+
+    if (isFlatpakRuntime) {
+        // In Flatpak, search multiple possible locations for exported desktop files
+        searchPaths = {QDir::homePath() + QStringLiteral("/.var/app/io.github.DenysMb.Kontainer/data/applications"),
+                       QDir::homePath() + QStringLiteral("/.var/app/io.github.DenysMb.Kontainer/.local/share/applications"),
+                       QStringLiteral("/var/lib/flatpak/exports/share/applications"),
+                       QDir::homePath() + QStringLiteral("/.local/share/flatpak/exports/share/applications"),
+                       QDir::homePath() + QStringLiteral("/.local/share/applications")};
+    } else {
+        searchPaths = {QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation)};
+    }
+
+    QStringList patterns;
+    patterns << QStringLiteral("%1.desktop").arg(container);
+
+    // Search in all possible paths
+    for (const QString &searchPath : searchPaths) {
+        QDir dir(searchPath);
+        if (!dir.exists())
+            continue;
+
+        for (const QFileInfo &file : dir.entryInfoList(patterns, QDir::Files)) {
+            if (!file.fileName().endsWith(QStringLiteral(".desktop")))
+                continue;
+
+            QSettings desktop(file.filePath(), QSettings::IniFormat);
+            QString foundIcon = desktop.value(QStringLiteral("Desktop Entry/Icon"), QString()).toString();
+
+            // Stop at first .desktop (even if no icon is set)
+            if (!foundIcon.isEmpty())
+                return foundIcon;
+            else
+                return QStringLiteral("preferences-virtualization-container");
+        }
+    }
+
+    // Fallback if no .desktop file was found at all
+    return QStringLiteral("preferences-virtualization-container");
+}
+
+}

--- a/src/utils/distroicons.h
+++ b/src/utils/distroicons.h
@@ -1,0 +1,13 @@
+/*
+ *   SPDX-License-Identifier: GPL-3.0-or-later
+ *   SPDX-FileCopyrightText: 2025 Hadi Chokr <hadichokr@icloud.com>
+ */
+
+#pragma once
+
+#include <QString>
+
+namespace DistroIcons
+{
+QString resolveDistroboxIcon(const QString container);
+}


### PR DESCRIPTION
Allows you to switch from just colours to using Distro Icons provided by distrobox shortcuts. Its persistent so your Prefernce wont be wiped, by default show Icons. You can switch between them in the Drawer.

Fixes https://github.com/DenysMb/Kontainer/issues/22