### PR TITLE
Remove kirigami-addons module.

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -14,25 +14,6 @@
   ],
   "modules": [
     {
-      "name": "kirigami-addons",
-      "buildsystem": "cmake-ninja",
-      "config-opts": ["-DBUILD_TESTING=OFF"],
-      "builddir": true,
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.9.0.tar.xz",
-          "sha256": "21314a91f26b1c962def3fd7ff2e762d3358b075f63f4d7e0144fb2c63b7ebc7",
-          "x-checker-data": {
-            "type": "anitya",
-            "project-id": 242933,
-            "stable-only": true,
-            "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-          }
-        }
-      ]
-    },
-    {
       "name": "kontainer",
       "buildsystem": "cmake-ninja",
       "config-opts": ["-DCMAKE_BUILD_TYPE=Release"],


### PR DESCRIPTION
I added kirigami-addons into our flatpak sdk at KDE. Now it isnt necessary to built kirigami-addons as an module anymore.

Fixes #41 