### PR TITLE
Wrap all commands in env to resolve full paths 

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -17,25 +17,6 @@
   ],
   "modules": [
     {
-      "name": "kirigami-addons",
-      "buildsystem": "cmake-ninja",
-      "config-opts": ["-DBUILD_TESTING=OFF"],
-      "builddir": true,
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.9.0.tar.xz",
-          "sha256": "21314a91f26b1c962def3fd7ff2e762d3358b075f63f4d7e0144fb2c63b7ebc7",
-          "x-checker-data": {
-            "type": "anitya",
-            "project-id": 242933,
-            "stable-only": true,
-            "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-          }
-        }
-      ]
-    },
-    {
       "name": "kontainer",
       "buildsystem": "cmake-ninja",
       "config-opts": ["-DCMAKE_BUILD_TYPE=Release"],

--- a/src/core/distroboxcli.cpp
+++ b/src/core/distroboxcli.cpp
@@ -26,7 +26,7 @@ namespace DistroboxCli
 {
 QString runCommand(const QString &command, bool &success)
 {
-    QString actualCommand = command;
+    QString actualCommand = u"/usr/bin/env "_s + command;
     if (isFlatpakRuntime()) {
         actualCommand = u"flatpak-spawn --host "_s + command;
     }


### PR DESCRIPTION
Also drop kirigami addons from the development flatpak manifest as it is unnecessary.

Closes #45 

@DenysMb @Philantrop