### PR TITLE
Bugfix: Also wrap all commands inside the flatpak with env.

### DIFF
--- a/src/core/distroboxcli.cpp
+++ b/src/core/distroboxcli.cpp
@@ -27,10 +27,10 @@ namespace DistroboxCli
 QString runCommand(const QString &command, bool &success)
 {
     QString actualCommand = u"/usr/bin/env "_s + command;
+
     if (isFlatpakRuntime()) {
         actualCommand = u"flatpak-spawn --host /usr/bin/env "_s + command;
     }
-    qDebug() << "Actual command:" << actualCommand;
 
     QString output;
     QProcess process;


### PR DESCRIPTION
Commands launched via flatpak spawn didnt get wrapped by my previous MR as i overlooked the = overwriting the previous actualCommand Variable. This fixes the tiny bug.