### PR TITLE
feat(distrobox): resolve document portal paths for custom home directories and volumes

### DIFF
--- a/.flatpak-manifest.json
+++ b/.flatpak-manifest.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.DenysMb.Kontainer",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.9",
+  "runtime-version": "6.10",
   "sdk": "org.kde.Sdk",
   "command": "kontainer",
   "finish-args": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.20)
-project(kontainer VERSION 1.5.0)
+project(kontainer VERSION 1.5.1)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.20)
-project(kontainer VERSION 1.5.1)
+project(kontainer VERSION 1.5.2)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/io.github.DenysMb.Kontainer.metainfo.xml
+++ b/io.github.DenysMb.Kontainer.metainfo.xml
@@ -62,6 +62,11 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+  <release version="1.5.1" date="2026-07-19">
+    <description>
+      <p>Change placeholder message on distrobox image selection input to make it clearer that users can write images name that are not in the list.</p>
+    </description>
+  </release>
   <release version="1.5.0" date="2026-07-12">
     <description>
       <p>Add support for Distrobox 2.0: strip container startup noise from stdout when auto-starting stopped containers, fixing missing app.</p>

--- a/io.github.DenysMb.Kontainer.metainfo.xml
+++ b/io.github.DenysMb.Kontainer.metainfo.xml
@@ -62,6 +62,11 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+  <release version="1.5.2" date="2026-07-25">
+    <description>
+      <p>Fix document portal path resolution for custom home directories and volumes in Flatpak. Folder selections now return real host paths so distrobox create receives the correct directory even without filesystem permissions.</p>
+    </description>
+  </release>
   <release version="1.5.1" date="2026-07-19">
     <description>
       <p>Change placeholder message on distrobox image selection input to make it clearer that users can write images name that are not in the list.</p>

--- a/po/pt/kontainer.po
+++ b/po/pt/kontainer.po
@@ -579,8 +579,8 @@ msgstr "Prévia do comando"
 
 #: src/qml/DistroboxCreateDialog.qml:685
 #, kde-format
-msgid "Search images…"
-msgstr ""
+msgid "Search or type a custom image…"
+msgstr "Pesquise ou digite uma imagem personalizada…"
 
 #: src/qml/DistroboxCreateDialog.qml:763
 #, kde-format

--- a/src/core/distroboxmanager.cpp
+++ b/src/core/distroboxmanager.cpp
@@ -25,6 +25,7 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QUrl>
+#include <cstring>
 #include <distroicons.h>
 #include <sys/xattr.h>
 
@@ -85,14 +86,18 @@ static QString resolveDocumentPortalPath(const QString &path)
     if (!path.contains(QStringLiteral("/doc/")))
         return path;
 
-    QByteArray value(4096, '\0');
-    ssize_t len = getxattr(path.toLocal8Bit().constData(), "user.document-portal.host-path", value.data(), value.size());
-    if (len > 0) {
-        return QString::fromUtf8(value.constData(), len);
-    }
+    const QByteArray pathUtf8 = path.toLocal8Bit();
+    const ssize_t size = getxattr(pathUtf8.constData(), "user.document-portal.host-path", nullptr, 0);
+    if (size <= 0)
+        return path;
 
-    // No xattr or error — fallback to original path
-    return path;
+    QByteArray value(size, '\0');
+    const ssize_t len = getxattr(pathUtf8.constData(), "user.document-portal.host-path", value.data(), value.size());
+    if (len <= 0)
+        return path;
+
+    // Older xdg-desktop-portal versions include a trailing NUL in the xattr value
+    return QString::fromUtf8(value.constData(), strnlen(value.constData(), len));
 }
 
 QString resolveIconPathInContainer(const QString &container, const QString &iconValue)
@@ -475,6 +480,11 @@ bool DistroboxManager::installPackageInContainer(const QString &name, const QStr
 bool DistroboxManager::isFlatpak() const
 {
     return DistroboxCli::isFlatpak();
+}
+
+QString DistroboxManager::resolveHostPath(const QString &path) const
+{
+    return resolveDocumentPortalPath(path);
 }
 
 bool DistroboxManager::isContainerEngineAvailable() const

--- a/src/core/distroboxmanager.h
+++ b/src/core/distroboxmanager.h
@@ -219,6 +219,13 @@ public Q_SLOTS:
      */
     Q_INVOKABLE bool unexportApp(const QString &basename, const QString &container);
 
+    /**
+     * @brief Resolves a document portal path to the real path on the host
+     * @param path Path returned by a portal file dialog (e.g. /run/user/1000/doc/...)
+     * @return Real path on the host, or the original path if it is not a portal path or cannot be resolved
+     */
+    Q_INVOKABLE QString resolveHostPath(const QString &path) const;
+
 Q_SIGNALS:
     /**
      * @brief Emitted when a container clone operation finishes.

--- a/src/qml/DistroboxCreateDialog.qml
+++ b/src/qml/DistroboxCreateDialog.qml
@@ -74,7 +74,7 @@ Kirigami.Dialog {
         id: homeDirectoryDialog
         title: i18n("Select custom home directory")
         onAccepted: {
-            createDialog.customHomePath = selectedFolder.toString().replace("file://", "");
+            createDialog.customHomePath = distroBoxManager.resolveHostPath(selectedFolder.toString().replace("file://", ""));
         }
     }
 
@@ -82,7 +82,7 @@ Kirigami.Dialog {
         id: volumeDirectoryDialog
         title: i18n("Select volume directory")
         onAccepted: {
-            var volumePath = selectedFolder.toString().replace("file://", "");
+            var volumePath = distroBoxManager.resolveHostPath(selectedFolder.toString().replace("file://", ""));
             // Check for duplicates
             for (var i = 0; i < volumesModel.count; i++) {
                 if (volumesModel.get(i).path === volumePath) {

--- a/src/qml/DistroboxCreateDialog.qml
+++ b/src/qml/DistroboxCreateDialog.qml
@@ -682,7 +682,7 @@ Kirigami.Dialog {
                 id: imageSearchField
                 Layout.fillWidth: true
                 enabled: !createDialog.isCreating
-                placeholderText: i18n("Search images…")
+                placeholderText: i18n("Search or type a custom image…")
                 onTextChanged: updateFilteredImages(text)
             }
 


### PR DESCRIPTION
- Fix document portal path resolution in Flatpak. Folder selections now return real host paths via the `user.document-portal.host-path` xattr (same technique as DistroShelf). No Flatpak permission changes needed. Closes #65.
- Clarify image placeholder so users can type custom image names not in the list. Closes #74.